### PR TITLE
Canonicalize most expressions

### DIFF
--- a/src/Tao.hs
+++ b/src/Tao.hs
@@ -37,7 +37,7 @@ data Expr
   | Rec ![(String, Expr)]
   | Get !Expr !String
   | Set !Expr ![(String, Expr)]
-  | SumT !String ![Alt]
+  | SumT ![Alt]
   | Ctr !String !String
   | Var !String
   | ForT !String !Expr
@@ -160,7 +160,7 @@ eq :: Expr -> Expr -> Expr
 eq a b = app (Op Eq) [a, b]
 
 boolT :: Expr
-boolT = SumT "Bool" [("True", ([], Var "Bool")), ("False", ([], Var "Bool"))]
+boolT = SumT [("True", ([], Var "Bool")), ("False", ([], Var "Bool"))]
 
 prelude :: Env
 prelude =
@@ -189,9 +189,46 @@ findNameIdx (x : xs) prefix = case findNameIdx xs prefix of
   Nothing -> if prefix == x then Just 0 else readNameIdx prefix x
 
 -- Type checking --
--- TODO: is this safe to do or should this be defined manually?
 occurs :: String -> Expr -> Bool
-occurs x a = compile [] a |> Core.occurs x
+occurs _ Err = False
+occurs _ TypT = False
+occurs _ IntT = False
+occurs _ (Int _) = False
+occurs x (TupT itemsT) = any (occurs x) itemsT
+occurs x (Tup items) = any (occurs x) items
+occurs x (RecT fieldsT) = any (snd .> occurs x) fieldsT
+occurs x (Rec fields) = any (snd .> occurs x) fields
+occurs x (Get a _) = occurs x a
+occurs x (Set a fields) = occurs x a || any (snd .> occurs x) fields
+occurs x (SumT alts) = any (snd .> snd .> occurs x) alts
+occurs _ (Ctr _ _) = False
+occurs x (Var y) = x == y
+occurs x (ForT y a) | x /= y = occurs x a
+occurs _ (ForT _ _) = False
+occurs x (FunT a b) = any (occurs x) [a, b]
+occurs x (Lam y a) | x /= y = occurs x a
+occurs _ (Lam _ _) = False
+occurs x (App a b) = any (occurs x) [a, b]
+occurs x (Ann a b) = any (occurs x) [a, b]
+occurs x (If cond then' else') = any (occurs x) [cond, then', else']
+occurs x (Let _ a) = occurs x a
+occurs x (Match cases) = any (occursCase x) cases
+occurs x (TypeOf a) = occurs x a
+occurs x (Op (Call _ t)) = occurs x t
+occurs _ (Op _) = False
+
+occursCase :: String -> Case -> Bool
+occursCase x ([], a) = occurs x a
+occursCase x (PAny : ps, a) = occursCase x (ps, a)
+occursCase x (PVar y : ps, a) = occursCase x (PAs PAny y : ps, a)
+occursCase x (PAs p y : ps, a) | x /= y = occursCase x (p : ps, a)
+occursCase _ (PAs _ _ : _, _) = False
+occursCase x (PCtr _ qs : ps, a) = occursCase x (qs ++ ps, a)
+occursCase x (PTup qs : ps, a) = occursCase x (qs ++ ps, a)
+occursCase x (PRec fieldsP : ps, a) = occursCase x (map snd fieldsP ++ ps, a)
+occursCase x (PAnn p t : ps, a) = occursCase x (p : t : ps, a)
+occursCase x (PEq b : ps, a) = occurs x b || occursCase x (ps, a)
+occursCase x (PIf p cond : ps, a) = occurs x cond || occursCase x (p : ps, a)
 
 substitute :: String -> Expr -> Expr -> Expr
 substitute x a b = decompile (compile [] (Let [(x, a)] b))
@@ -215,6 +252,8 @@ unify env a b = case (reduce env a, reduce env b) of
   (a, ForT x b) -> do
     let (b', env') = instantiate env (ForT x b)
     unify env' a b'
+  (FunT {}, TypT) -> Right env
+  (TypT, FunT {}) -> Right env
   (FunT a1 a2, FunT b1 b2) -> unify2 env (a1, b1) (a2, b2)
   (App a1 a2, App b1 b2) -> unify2 env (a1, b1) (a2, b2)
   (a, a') | a == a' -> Right env
@@ -266,14 +305,14 @@ infer env (Set a fields) = do
       let key (x, _) (y, _) = x == y
       Right (RecT (sortOn fst (unionBy key fieldsT' fieldsT)), env)
     t -> Left (NotARecord a t)
-infer env (SumT _ _) = Right (TypT, env)
+infer env (SumT _) = Right (TypT, env)
 infer env (Ctr tname cname) = case lookup tname env of
   Just a -> case asLam a of
-    -- TODO: check that tname matches
-    (xs, SumT tname alts) -> case lookup cname alts of
+    (xs, SumT alts) -> case lookup cname alts of
       Just (_, type') -> do
-        (type', _) <- eval (map (\x -> (x, Var x)) xs ++ env) type'
-        Right (type', env)
+        let env' = map (\x -> (x, Var x)) xs ++ env
+        (type', _) <- eval env' type'
+        Right (forT xs type', env)
       Nothing -> Left (CtrNotInSumType tname cname (map fst alts))
     _else -> Left (NotASumType tname a)
   Nothing -> Left (UndefinedType tname)
@@ -374,7 +413,7 @@ freeVars (RecT fieldsT) = concatMap (snd .> freeVars) fieldsT
 freeVars (Rec fields) = concatMap (snd .> freeVars) fields
 freeVars (Get a _) = freeVars a
 freeVars (Set a fields) = freeVars a `union` concatMap (snd .> freeVars) fields
-freeVars (SumT name alts) = delete name (concatMap (snd .> snd .> freeVars) alts)
+freeVars (SumT alts) = concatMap (snd .> snd .> freeVars) alts
 freeVars (Ctr _ _) = []
 freeVars (Var x) = [x]
 freeVars (ForT x a) = delete x (freeVars a)
@@ -423,7 +462,7 @@ ctrType env cname = case lookup cname env of
 typeAlts :: Env -> String -> Either TypeError [Alt]
 typeAlts env tname = case lookup tname env of
   Just a -> case asLam a of
-    (_, SumT _ alts) -> Right alts
+    (_, SumT alts) -> Right alts
     _else -> Left (NotASumType tname a)
   Nothing -> Left (UndefinedType tname)
 
@@ -497,12 +536,11 @@ compile env (Set a fields) = case infer env a of
     let setter = lam xs (Rec (map set ys))
     compile env (App a setter)
   _notARecord -> Core.Err
-compile _ (SumT name alts) = do
-  let branch :: Alt -> Expr
-      branch (_, (_, type')) = do
-        let (targs, _) = asFunT type'
-        funT targs (Var name)
-  compile [] (ForT name (funT (map branch alts) (Var name)))
+compile _ (SumT []) = Core.Err
+compile env (SumT ((cname, _) : _)) = case lookup cname env of
+  Just (Ctr tname _) -> case asLam (reduce env (Var tname)) of
+    (_, tdef) -> compile [] tdef
+  _else -> Core.Err
 compile env (Ctr tname cname) = do
   let alts = case typeAlts env tname of
         Right alts -> alts
@@ -512,9 +550,16 @@ compile env (Ctr tname cname) = do
   compile env (lam (xs ++ map fst alts) (app (Var cname) (map Var xs)))
 compile env (Var x) = case lookup x env of
   Just (Var x') | x == x' -> Core.Var x
-  Just a -> case compile ((x, Var x) : env) a of
-    Core.Lam env y a' | x `Core.occurs` a' -> Core.Fix x (Core.Lam env y a')
-    a' -> a'
+  Just a -> case asLam a of
+    (xs, SumT alts) -> do
+      let branch :: Alt -> Expr
+          branch (_, (_, type')) = do
+            let (targs, _) = asFunT type'
+            funT targs (Var x)
+      compile [] (lam xs (ForT x (funT (map branch alts) (Var x))))
+    _else -> case compile ((x, Var x) : env) a of
+      Core.Lam env y a' | x `Core.occurs` Core.Lam [] y a' -> Core.Fix x (Core.Lam env y a')
+      a' -> a'
   Nothing -> Core.Var x
 compile env (ForT x a) = Core.ForT x (compile ((x, Var x) : env) a)
 compile env (FunT a b) = Core.FunT (compile env a) (compile env b)
@@ -557,51 +602,61 @@ decompile (Core.Op (Core.Call f t)) = Op (Call f (decompile t))
 reduce :: Env -> Expr -> Expr
 reduce env expr = compile env expr |> Core.reduce [] |> decompile
 
+canonical :: Env -> Expr -> Expr -> Either TypeError (Expr, Expr)
+canonical _ (ForT "()" t) type' = do
+  let (xs, t') = asForT t
+  let itemsT = fst (asFunT t')
+  case xs of
+    [] -> Right (TupT itemsT, type')
+    xs -> Right (RecT (zip xs itemsT), type')
+canonical env (ForT x t) TypT = case asFunT t of
+  (_, Var tname) | x == tname -> do
+    let tdef = fromMaybe (ForT x t) (lookup x env)
+    case asLam tdef of
+      (xs, SumT alts) -> do
+        let env' = map (\x -> (x, Var x)) xs ++ env
+        let sumT = compile env' (SumT alts) |> decompile
+        env' <- unify env' sumT (ForT x t)
+        let evalAlt :: Alt -> Either TypeError Alt
+            evalAlt (cname, (xs, t)) = do
+              (t, _) <- eval ((x, Var x) : env') t
+              Right (cname, (xs, t))
+        alts' <- mapM evalAlt alts
+        Right (SumT alts', TypT)
+      _else -> Right (ForT x t, TypT)
+  _else -> Right (ForT x t, TypT)
+canonical _ (Lam "()" body) TypT = do
+  let itemsT = snd (asApp body)
+  Right (TupT itemsT, TypT)
+canonical _ (Lam "()" body) (TupT itemsT) = do
+  let items = snd (asApp body)
+  Right (Tup items, TupT itemsT)
+canonical _ (Lam "()" body) (RecT fieldsT) = do
+  let items = snd (asApp body)
+  Right (Rec (zip (map fst fieldsT) items), RecT fieldsT)
+canonical env expr type' = do
+  let (_, body) = asLam expr
+  let (_, funT) = asForT type'
+  case (fst (asApp body), snd (asFunT funT)) of
+    (Var cname, SumT _) -> case lookup cname env of
+      Just ctr@Ctr {} -> Right (ctr, type')
+      _else -> Right (expr, type')
+    _else -> Right (expr, type')
+
 eval :: Env -> Expr -> Either TypeError (Expr, Expr)
 eval env expr = do
   (type', _) <- infer env expr
   case reduce env expr of
     ForT x t -> do
       (t, _) <- eval ((x, Var x) : env) t
-      let (xs, funT) = asForT t
-      case (x, asFunT funT) of
-        ("()", (itemsT, Var "()")) | null xs -> Right (TupT itemsT, type')
-        ("()", (itemsT, Var "()")) -> Right (RecT (zip xs itemsT), type')
-        (x, (_, Var x')) | x == x' -> do
-          let tdef = fromMaybe (ForT x t) (lookup x env)
-          case asLam tdef of
-            (xs, SumT tname alts) -> do
-              let sumT = compile env (SumT tname alts) |> decompile
-              env' <- unify (map (\x -> (x, Var x)) xs ++ env) sumT (ForT x t)
-              let evalAlt :: Alt -> Either TypeError Alt
-                  evalAlt (cname, (xs, t)) = do
-                    (t, _) <- eval ((tname, Var tname) : env') t
-                    Right (cname, (xs, t))
-              alts' <- mapM evalAlt alts
-              Right (SumT tname alts', type')
-            _else -> Right (ForT x t, type')
-        _else -> Right (ForT x t, type')
+      canonical env (ForT x t) type'
     FunT a b -> do
       (a, _) <- eval env a
       (b, _) <- eval env b
-      Right (FunT a b, type')
+      canonical env (FunT a b) type'
     Lam x body -> do
-      (_, env') <- infer env (Lam x body)
-      (body, _) <- eval env' body
-      case (x, asFunT type') of
-        ("()", (_, TupT itemsT)) -> case asApp body of
-          (Var "()", items) -> Right (Tup items, TupT itemsT)
-          _else -> Right (Lam x body, type')
-        ("()", (_, RecT fieldsT)) -> case asApp body of
-          (Var "()", items) -> Right (Rec (zip (map fst fieldsT) items), RecT fieldsT)
-          _else -> Right (Lam x body, type')
-        (_, (_, SumT {})) -> do
-          case Lam x body |> asLam |> snd |> asApp of
-            (Var cname, _) -> case lookup cname env of
-              Just ctr@Ctr {} -> Right (ctr, type')
-              _else -> Right (Lam x body, type')
-            _else -> Right (Lam x body, type')
-        _else -> Right (Lam x body, type')
+      (body, _) <- eval ((x, Var x) : env) body
+      canonical env (Lam x body) type'
     App a b -> do
       (a, aT) <- eval env a
       (b, _) <- eval env b
@@ -615,4 +670,5 @@ eval env expr = do
               Right (Set a fields, type')
             _else -> Right (App a b, type')
         _else -> Right (App a b, type')
+    Op (Call f _) -> Right (Op (Call f type'), type')
     result -> Right (result, type')

--- a/src/TaoLang.hs
+++ b/src/TaoLang.hs
@@ -1,4 +1,42 @@
-module TaoLang where
+module TaoLang
+  ( Tao.Expr (..),
+    Tao.Operator (..),
+    Tao.Pattern (..),
+    Tao.add,
+    Tao.eq,
+    Tao.mul,
+    Tao.prelude,
+    Tao.sub,
+    TaoLang.eval,
+    block,
+    builtin,
+    case',
+    comment,
+    define,
+    emptyLine,
+    expression,
+    identifier,
+    loadBlock,
+    loadDef,
+    loadEnv,
+    loadExpr,
+    loadFile,
+    loadModule,
+    match,
+    maybeNewLine,
+    newLine,
+    operator,
+    parseBlock,
+    parseDef,
+    parseEnv,
+    parseExpr,
+    pattern',
+    record,
+    rule,
+    rules,
+    tuple,
+  )
+where
 
 import Control.Monad (void)
 import Data.List (sort)
@@ -72,17 +110,10 @@ eval env expr = case Tao.eval env expr of
   Right (result, type') -> Right (result, type')
   Left err -> Left (TypeError err)
 
-lowerName :: Parser String
-lowerName = do
+identifier :: Parser Char -> Parser String
+identifier firstChar = do
   -- TODO: support `-` and other characters, maybe URL-like names
-  c <- lowercase
-  cs <- zeroOrMore (oneOf [alphanumeric, char '_'])
-  succeed (c : cs)
-
-upperName :: Parser String
-upperName = do
-  -- TODO: support `-` and other characters, maybe URL-like names, or keep types CamelCase?
-  c <- uppercase
+  c <- firstChar
   cs <- zeroOrMore (oneOf [alphanumeric, char '_'])
   succeed (c : cs)
 
@@ -164,22 +195,35 @@ tuple indent = do
   _ <- char ')'
   succeed items
 
-record :: String -> Parser [(String, Expr)]
-record indent = do
-  let item = do
-        name <- token lowerName
-        _ <- token (char '=')
-        value <- expression indent
-        succeed (name, value)
+field :: Parser delim -> String -> Parser (String, Expr)
+field delimiter indent = do
+  name <- token (identifier lowercase)
+  _ <- token delimiter
+  value <- expression indent
+  succeed (name, value)
+
+record :: Parser delim -> String -> Parser [(String, Expr)]
+record delimiter indent = do
   _ <- token (char '(')
-  field <- item
-  fields <- zeroOrMore (do _ <- token (char ','); token item)
+  field' <- field delimiter indent
+  fields <- zeroOrMore (do _ <- token (char ','); token (field delimiter indent))
   _ <- maybe' (token (char ','))
   _ <- char ')'
-  succeed (field : fields)
+  succeed (field' : fields)
 
-pattern :: String -> Parser Pattern
-pattern indent = do
+recordSet :: String -> Parser Expr
+recordSet indent = do
+  _ <- token (char '(')
+  expr <- token (expression indent)
+  _ <- token (char '|')
+  field' <- field (char '=') indent
+  fields <- zeroOrMore (do _ <- token (char ','); token (field (char '=') indent))
+  _ <- maybe' (token (char ','))
+  _ <- char ')'
+  succeed (Set expr (field' : fields))
+
+pattern' :: String -> Parser Pattern
+pattern' indent = do
   p <-
     oneOf
       [ -- Pattern wildcard: _
@@ -188,26 +232,26 @@ pattern indent = do
         fmap (PEq . Int) integer,
         do
           -- Variable equality pattern
-          x <- lowerName
+          x <- identifier lowercase
           _ <- char '\''
           succeed (PEq (Var x)),
         do
           -- Named pattern: x@_
-          x <- token lowerName
+          x <- token (identifier lowercase)
           _ <- token (char '@')
-          p <- token (pattern indent)
+          p <- token (pattern' indent)
           succeed (PAs p x),
         -- Variable pattern: x
-        fmap PVar lowerName,
+        fmap PVar (identifier lowercase),
         do
           -- Constructor 0-arity: Nil
-          ctr <- upperName
+          ctr <- identifier uppercase
           succeed (PCtr ctr []),
         do
           -- Constructor n-arity: Cons x xs
           _ <- token (char '(')
-          ctr <- token upperName
-          ps <- zeroOrMore (token (pattern indent))
+          ctr <- token (identifier uppercase)
+          ps <- zeroOrMore (token (pattern' indent))
           _ <- char ')'
           succeed (PCtr ctr ps),
         do
@@ -218,15 +262,15 @@ pattern indent = do
         do
           -- Tuple pattern: (x, y)
           _ <- token (char '(')
-          p <- token (pattern indent)
-          ps <- oneOrMore (do _ <- token (char ','); token (pattern indent))
+          p <- token (pattern' indent)
+          ps <- oneOrMore (do _ <- token (char ','); token (pattern' indent))
           _ <- maybe' (token (char ','))
           _ <- char ')'
           succeed (PTup (p : ps)),
         do
           -- Tuple singleton pattern: (x,)
           _ <- token (char '(')
-          p <- token (pattern indent)
+          p <- token (pattern' indent)
           _ <- token (char ',')
           _ <- char ')'
           succeed (PTup [p]),
@@ -236,12 +280,12 @@ pattern indent = do
                 oneOf
                   [ do
                       _ <- token (char '.')
-                      x <- lowerName
+                      x <- identifier lowercase
                       succeed (x, PVar x),
                     do
-                      x <- token lowerName
+                      x <- token (identifier lowercase)
                       _ <- token (char '=')
-                      p <- pattern indent
+                      p <- pattern' indent
                       succeed (x, p)
                   ]
           _ <- token (char '(')
@@ -252,9 +296,9 @@ pattern indent = do
           succeed (PRec (field : fields)),
         do
           _ <- token (char '(')
-          p <- token (pattern indent)
+          p <- token (pattern' indent)
           _ <- token (char ':')
-          t <- token (pattern indent)
+          t <- token (pattern' indent)
           _ <- char ')'
           succeed (PAnn p t),
         do
@@ -275,7 +319,7 @@ pattern indent = do
 
 case' :: String -> Parser Case
 case' indent = do
-  ps <- oneOrMore (token (pattern indent))
+  ps <- oneOrMore (token (pattern' indent))
   _ <- token (text "->")
   indent <- maybeNewLine indent
   expr <- block indent
@@ -290,7 +334,7 @@ match indent = do
 
 rule :: String -> Parser ([Pattern], Expr)
 rule indent = do
-  ps <- zeroOrMore (token (pattern indent))
+  ps <- zeroOrMore (token (pattern' indent))
   _ <- token (char '=')
   indent <- maybeNewLine indent
   expr <- block indent
@@ -310,7 +354,7 @@ define indent = do
   oneOf
     [ do
         -- Typed one-line definition
-        name <- token lowerName
+        name <- token (identifier lowercase)
         _ <- token (char ':')
         type' <- token (expression indent)
         _ <- token (char '=')
@@ -319,7 +363,7 @@ define indent = do
         succeed [(name, Ann value type')],
       do
         -- Typed definition
-        name <- token lowerName
+        name <- token (identifier lowercase)
         _ <- token (char ':')
         type' <- token (expression indent)
         _ <- newLine indent
@@ -328,12 +372,12 @@ define indent = do
         succeed [(name, Ann value type')],
       do
         -- Untyped definition
-        name <- token lowerName
+        name <- token (identifier lowercase)
         value <- rules indent name
         succeed [(name, value)],
       do
         -- Pattern unpacking
-        p <- token (pattern indent)
+        p <- token (pattern' indent)
         _ <- token (char '=')
         indent <- maybeNewLine indent
         value <- block indent
@@ -349,7 +393,7 @@ definition indent = do
 builtin :: Parser Expr
 builtin = do
   _ <- char '@'
-  name <- token lowerName
+  name <- token (identifier letter)
   typ <- expression ""
   succeed (Op (Call name typ))
 
@@ -379,11 +423,13 @@ expression indent = do
           keyword IntT "Int",
           fmap Int integer,
           fmap Op operator,
+          recordSet indent,
           fmap Tup (tuple indent),
-          fmap Rec (record indent),
+          fmap RecT (record (char ':') indent),
+          fmap Rec (record (char '=') indent),
           annotatedExpr indent,
           match indent,
-          fmap Var lowerName,
+          fmap Var (identifier letter),
           builtin,
           parentheses indent
         ]
@@ -394,7 +440,7 @@ expression indent = do
         oneOf
           [ do
               _ <- char '.'
-              x <- lowerName
+              x <- identifier lowercase
               succeed (Get a x),
             succeed a
           ]

--- a/test/ExamplesTests.hs
+++ b/test/ExamplesTests.hs
@@ -1,13 +1,11 @@
 module ExamplesTests where
 
-import Tao
 import TaoLang
 import Test.Hspec
 
 examplesTests :: SpecWith ()
 examplesTests = describe "--== Examples end-to-end ==--" $ do
   let (x, y, z) = (Var "x", Var "y", Var "z")
-  -- let (p, q) = (Var "p", Var "q")
   let (x', y', z') = (PVar "x", PVar "y", PVar "z")
 
   it "☯ loadExpr" $ do
@@ -40,47 +38,58 @@ examplesTests = describe "--== Examples end-to-end ==--" $ do
   it "☯ loadModule" $ do
     loadModule "example/basic" `shouldReturn` [("x", Int 42), ("id", Match [([x'], x)])]
 
-  -- it "☯ syntax" $ do
-  --   let env =
-  --         ("p", Rec [("y", Int 2), ("x", Int 1)]) :
-  --         ("q", Ann q (RecT [("y", IntT), ("x", IntT)])) :
-  --         prelude
-  --   let run' src = do a <- parseBlock src; run env a
-  --   run' "!error" `shouldBe` Right (Err, Err)
-  --   run' "Type" `shouldBe` Right (TypT, TypT)
-  --   run' "Bool" `shouldBe` Right (boolT, TypT)
-  --   -- run' "True" `shouldBe` Right (true, boolT)
-  --   -- run' "False" `shouldBe` Right (false, boolT)
-  --   run' "Int" `shouldBe` Right (IntT, TypT)
-  --   run' "42" `shouldBe` Right (Int 42, IntT)
-  -- -- run' "()" `shouldBe` Right (Tup [], Tup [])
-  -- -- run' "(1,)" `shouldBe` Right (Tup [Int 1], Tup [IntT])
-  -- -- run' "(1, Int)" `shouldBe` Right (Tup [Int 1, IntT], Tup [IntT, TypT])
-  -- -- run' "(1, Int,)" `shouldBe` Right (Tup [Int 1, IntT], Tup [IntT, TypT])
-  -- -- run' "(x = 1)" `shouldBe` Right (Rec [("x", Int 1)], Rec [("x", IntT)])
-  -- -- run' "(x = 1,)" `shouldBe` Right (Rec [("x", Int 1)], Rec [("x", IntT)])
-  -- -- run' "(x = 1, y = 2)" `shouldBe` Right (Rec [("x", Int 1), ("y", Int 2)], Rec [("x", IntT), ("y", IntT)])
-  -- -- run' "(y = 2, x = 1,)" `shouldBe` Right (Rec [("x", Int 1), ("y", Int 2)], Rec [("x", IntT), ("y", IntT)])
-  -- -- run' "(x = 1).x" `shouldBe` Right (Int 1, IntT)
-  -- -- run' "p.x" `shouldBe` Right (Int 1, IntT)
+  it "☯ eval" $ do
+    let env =
+          ("p", Rec [("y", Int 2), ("x", Int 1)]) :
+          ("q", Ann (Var "q") (RecT [("y", IntT), ("x", IntT)])) :
+          prelude
+    let eval src = do a <- parseBlock src; TaoLang.eval env a
+    eval "!error" `shouldBe` Right (Err, Err)
+    eval "Type" `shouldBe` Right (TypT, TypT)
+    eval "Int" `shouldBe` Right (IntT, TypT)
+    eval "42" `shouldBe` Right (Int 42, IntT)
+    eval "(() : Type)" `shouldBe` Right (TupT [], TypT)
+    eval "((Int,) : Type)" `shouldBe` Right (TupT [IntT], TypT)
+    eval "()" `shouldBe` Right (Tup [], TupT [])
+    eval "(1,)" `shouldBe` Right (Tup [Int 1], TupT [IntT])
+    eval "(1, Int)" `shouldBe` Right (Tup [Int 1, IntT], TupT [IntT, TypT])
+    eval "(1, Int,)" `shouldBe` Right (Tup [Int 1, IntT], TupT [IntT, TypT])
+    eval "(x : Int)" `shouldBe` Right (RecT [("x", IntT)], TypT)
+    eval "(x : Int,)" `shouldBe` Right (RecT [("x", IntT)], TypT)
+    eval "(x : Int, y : Type)" `shouldBe` Right (RecT [("x", IntT), ("y", TypT)], TypT)
+    eval "(y : Type, x : Int,)" `shouldBe` Right (RecT [("x", IntT), ("y", TypT)], TypT)
+    eval "(x = 1)" `shouldBe` Right (Rec [("x", Int 1)], RecT [("x", IntT)])
+    eval "(x = 1,)" `shouldBe` Right (Rec [("x", Int 1)], RecT [("x", IntT)])
+    eval "(x = 1, y = 2)" `shouldBe` Right (Rec [("x", Int 1), ("y", Int 2)], RecT [("x", IntT), ("y", IntT)])
+    eval "(y = 2, x = 1,)" `shouldBe` Right (Rec [("x", Int 1), ("y", Int 2)], RecT [("x", IntT), ("y", IntT)])
+    eval "(x = 1).x" `shouldBe` Right (Int 1, IntT)
+    eval "p.x" `shouldBe` Right (Int 1, IntT)
+    eval "p.y" `shouldBe` Right (Int 2, IntT)
+    eval "q.x" `shouldBe` Right (Get (Var "q") "x", IntT)
+    eval "q.y" `shouldBe` Right (Get (Var "q") "y", IntT)
+    eval "(p | x = Int)" `shouldBe` Right (Rec [("x", IntT), ("y", Int 2)], RecT [("x", TypT), ("y", IntT)])
+    eval "(p | x = Int,)" `shouldBe` Right (Rec [("x", IntT), ("y", Int 2)], RecT [("x", TypT), ("y", IntT)])
+    eval "(p | x = Int, y = 0)" `shouldBe` Right (Rec [("x", IntT), ("y", Int 0)], RecT [("x", TypT), ("y", IntT)])
+    eval "(q | x = Int)" `shouldBe` Right (Set (Var "q") [("x", IntT)], RecT [("x", TypT), ("y", IntT)])
+  -- eval "| A" `shouldBe` Right (SumT "" [()], Err)
 
   it "☯ factorial" $ do
     env <- loadFile "example/e2e" "factorial.tao"
     let f = Var "factorial"
-    let factorial n = Tao.eval (env ++ prelude) (App f (Int n))
+    let factorial n = eval (env ++ prelude) (App f (Int n))
     factorial 0 `shouldBe` Right (Int 1, IntT)
     factorial 1 `shouldBe` Right (Int 1, IntT)
     factorial 5 `shouldBe` Right (Int 120, IntT)
-    fmap snd (Tao.eval (env ++ prelude) f) `shouldBe` Right (FunT IntT IntT)
+    fmap snd (eval (env ++ prelude) f) `shouldBe` Right (FunT IntT IntT)
 
   it "☯ fibonacci" $ do
     env <- loadFile "example/e2e" "fibonacci.tao"
     let f = Var "fibonacci"
-    let fibonacci n = Tao.eval (env ++ prelude) (App f (Int n))
+    let fibonacci n = eval (env ++ prelude) (App f (Int n))
     fibonacci 0 `shouldBe` Right (Int 0, IntT)
     fibonacci 1 `shouldBe` Right (Int 1, IntT)
     fibonacci 2 `shouldBe` Right (Int 1, IntT)
     fibonacci 3 `shouldBe` Right (Int 2, IntT)
     fibonacci 4 `shouldBe` Right (Int 3, IntT)
     fibonacci 5 `shouldBe` Right (Int 5, IntT)
-    fmap snd (Tao.eval (env ++ prelude) f) `shouldBe` Right (FunT IntT IntT)
+    fmap snd (eval (env ++ prelude) f) `shouldBe` Right (FunT IntT IntT)

--- a/test/TaoLangTests.hs
+++ b/test/TaoLangTests.hs
@@ -1,7 +1,6 @@
 module TaoLangTests where
 
 import Parser
-import Tao
 import TaoLang
 import Test.Hspec
 
@@ -13,15 +12,10 @@ taoLangTests = describe "--==☯ Tao language ☯==--" $ do
         Right x -> Just x
         Left _ -> Nothing
 
-  it "☯ lowerName" $ do
-    parse' "" lowerName `shouldBe` Nothing
-    parse' "a" lowerName `shouldBe` Just "a"
-    parse' "a1" lowerName `shouldBe` Just "a1"
-
-  it "☯ upperName" $ do
-    parse' "" upperName `shouldBe` Nothing
-    parse' "A" upperName `shouldBe` Just "A"
-    parse' "A1" upperName `shouldBe` Just "A1"
+  it "☯ identifier" $ do
+    parse' "" (identifier lowercase) `shouldBe` Nothing
+    parse' "a" (identifier lowercase) `shouldBe` Just "a"
+    parse' "a1" (identifier lowercase) `shouldBe` Just "a1"
 
   it "☯ comment" $ do
     let comment' src = parse' src comment
@@ -77,42 +71,40 @@ taoLangTests = describe "--==☯ Tao language ☯==--" $ do
     tuple' "(x, y,)" `shouldBe` Just [x, y]
 
   it "☯ record" $ do
-    let record' src = parse' src (record "  ")
+    let record' src = parse' src (record (char '=') "  ")
     record' "()" `shouldBe` Nothing
     record' "(x = 1)" `shouldBe` Just [("x", Int 1)]
     record' "(x = 1, y = 2)" `shouldBe` Just [("x", Int 1), ("y", Int 2)]
 
-  it "☯ pattern" $ do
-    let pattern' src = parse' src (pattern "  ")
-    pattern' "" `shouldBe` Nothing
-    pattern' "_" `shouldBe` Just PAny
-    pattern' "42" `shouldBe` Just (PEq (Int 42))
-    pattern' "x'" `shouldBe` Just (PEq x)
-    pattern' "x@_" `shouldBe` Just (PAs PAny "x")
-    pattern' "x" `shouldBe` Just (PVar "x")
-    pattern' "A" `shouldBe` Just (PCtr "A" [])
-    pattern' "B x" `shouldBe` Just (PCtr "B" [])
-    pattern' "(B x)" `shouldBe` Just (PCtr "B" [x'])
-    pattern' "(C x y)" `shouldBe` Just (PCtr "C" [x', y'])
-    pattern' "()" `shouldBe` Just (PTup [])
-    pattern' "(x,)" `shouldBe` Just (PTup [x'])
-    pattern' "(x, y)" `shouldBe` Just (PTup [x', y'])
-    pattern' "(x, y,)" `shouldBe` Just (PTup [x', y'])
-    pattern' "(.x)" `shouldBe` Just (PRec [("x", x')])
-    pattern' "(.x,)" `shouldBe` Just (PRec [("x", x')])
-    pattern' "(.x, y = _)" `shouldBe` Just (PRec [("x", x'), ("y", PAny)])
-    pattern' "(.x, y = _,)" `shouldBe` Just (PRec [("x", x'), ("y", PAny)])
-    pattern' "(x : y)" `shouldBe` Just (PAnn x' y')
-    pattern' "(x)" `shouldBe` Just (PEq x)
-    pattern' "(x + y)" `shouldBe` Just (PEq (add x y))
-    pattern' "x | y" `shouldBe` Just (PIf x' y)
+  it "☯ pattern'" $ do
+    let pattern_ src = parse' src (pattern' "  ")
+    pattern_ "" `shouldBe` Nothing
+    pattern_ "_" `shouldBe` Just PAny
+    pattern_ "42" `shouldBe` Just (PEq (Int 42))
+    pattern_ "x'" `shouldBe` Just (PEq x)
+    pattern_ "x@_" `shouldBe` Just (PAs PAny "x")
+    pattern_ "x" `shouldBe` Just (PVar "x")
+    pattern_ "A" `shouldBe` Just (PCtr "A" [])
+    pattern_ "B x" `shouldBe` Just (PCtr "B" [])
+    pattern_ "(B x)" `shouldBe` Just (PCtr "B" [x'])
+    pattern_ "(C x y)" `shouldBe` Just (PCtr "C" [x', y'])
+    pattern_ "()" `shouldBe` Just (PTup [])
+    pattern_ "(x,)" `shouldBe` Just (PTup [x'])
+    pattern_ "(x, y)" `shouldBe` Just (PTup [x', y'])
+    pattern_ "(x, y,)" `shouldBe` Just (PTup [x', y'])
+    pattern_ "(.x)" `shouldBe` Just (PRec [("x", x')])
+    pattern_ "(.x,)" `shouldBe` Just (PRec [("x", x')])
+    pattern_ "(.x, y = _)" `shouldBe` Just (PRec [("x", x'), ("y", PAny)])
+    pattern_ "(.x, y = _,)" `shouldBe` Just (PRec [("x", x'), ("y", PAny)])
+    pattern_ "(x : y)" `shouldBe` Just (PAnn x' y')
+    pattern_ "(x)" `shouldBe` Just (PEq x)
+    pattern_ "(x + y)" `shouldBe` Just (PEq (add x y))
+    pattern_ "x | y" `shouldBe` Just (PIf x' y)
 
   it "☯ builtin" $ do
     let builtin' src = parse' src builtin
     builtin' "@" `shouldBe` Nothing
-  -- builtin' "@Int" `shouldBe` Just IntT
-  -- builtin' "@Type" `shouldBe` Just (TypeDef "Type" [])
-  -- builtin' "@func @Int" `shouldBe` Just (Op (Call "func" IntT))
+    builtin' "@x Int" `shouldBe` Just (Op (Call "x" IntT))
 
   it "☯ case'" $ do
     let case_ src = parse' src (case' "  ")

--- a/test/TaoTests.hs
+++ b/test/TaoTests.hs
@@ -12,9 +12,9 @@ taoTests = describe "--== Tao representation ==--" $ do
   let (x, y, z) = (Var "x", Var "y", Var "z")
   let (x', y', z') = (PAs PAny "x", PAs PAny "y", PAs PAny "z")
   let (xT, yT) = (Var "xT", Var "yT")
-  let neverT = SumT "Never" []
-  let unitT = SumT "Unit" [("A", ([], Var "Unit"))]
-  let monadT = SumT "Monad" [("M", (["x"], FunT a (App (Var "Monad") a)))]
+  let neverT = SumT []
+  let unitT = SumT [("A", ([], Var "Unit"))]
+  let monadT = SumT [("M", (["x"], FunT a (App (Var "Monad") a)))]
   let prelude =
         [ ("Never", neverT),
           ("Unit", unitT),
@@ -156,7 +156,7 @@ taoTests = describe "--== Tao representation ==--" $ do
     infer env (Ctr "x" "A") `shouldBe` Left (NotASumType "x" (Int 1))
     infer env (Ctr "Unit" "X") `shouldBe` Left (CtrNotInSumType "Unit" "X" ["A"])
     infer' env (Ctr "Unit" "A") `shouldBe` Right unitT
-    infer' env (Ctr "Monad" "M") `shouldBe` Right (FunT a monadT)
+    infer' env (Ctr "Monad" "M") `shouldBe` Right (ForT "a" (FunT a monadT))
     infer env (Var "x") `shouldBe` Right (IntT, env)
     infer env (Var "y") `shouldBe` Right (y, env)
     infer env (Var "z") `shouldBe` Left (UndefinedVar "z")
@@ -215,8 +215,8 @@ taoTests = describe "--== Tao representation ==--" $ do
     freeVars (Rec [("a", x)]) `shouldBe` ["x"]
     freeVars (Get x "a") `shouldBe` ["x"]
     freeVars (Set x [("a", y)]) `shouldBe` ["x", "y"]
-    freeVars unitT `shouldBe` []
-    freeVars monadT `shouldBe` ["a"]
+    freeVars unitT `shouldBe` ["Unit"]
+    freeVars monadT `shouldBe` ["a", "Monad"]
     freeVars (Ctr "T" "A") `shouldBe` []
     freeVars (Var "x") `shouldBe` ["x"]
     freeVars (ForT "x" x) `shouldBe` []
@@ -337,10 +337,10 @@ taoTests = describe "--== Tao representation ==--" $ do
     compile env (Set p [("y", Int 1), ("x", Int 2)]) `shouldBe` compile [] (App (Rec [("x", Int 1), ("y", Int 2)]) (lam ["x", "y"] (Rec [("x", Int 2), ("y", Int 1)])))
     compile env (Set p [("z", Int 3)]) `shouldBe` compile [] (App (Rec [("x", Int 1), ("y", Int 2)]) (lam ["x", "y"] (Rec [("x", x), ("y", y), ("z", Int 3)])))
     compile env (Set q [("z", Int 3)]) `shouldBe` compile [] (App q (lam ["x", "y"] (Rec [("x", x), ("y", y), ("z", Int 3)])))
-    compile env neverT `shouldBe` compile [] (ForT "Never" (Var "Never"))
-    compile env unitT `shouldBe` compile [] (ForT "Unit" (funT [Var "Unit"] (Var "Unit")))
-    compile env boolT `shouldBe` compile [] (ForT "Bool" (funT [Var "Bool", Var "Bool"] (Var "Bool")))
-    compile env monadT `shouldBe` compile [] (ForT "Monad" (FunT (FunT a (Var "Monad")) (Var "Monad")))
+    compile env (Var "Never") `shouldBe` compile [] (ForT "Never" (Var "Never"))
+    compile env (Var "Unit") `shouldBe` compile [] (ForT "Unit" (funT [Var "Unit"] (Var "Unit")))
+    compile env (Var "Bool") `shouldBe` compile [] (ForT "Bool" (funT [Var "Bool", Var "Bool"] (Var "Bool")))
+    compile env (Var "Monad") `shouldBe` compile [] (Lam "a" (ForT "Monad" (FunT (FunT a (Var "Monad")) (Var "Monad"))))
     compile env (Ctr "Unit" "A") `shouldBe` C.lam ["A"] (C.Var "A")
     compile env (Ctr "Bool" "True") `shouldBe` C.lam ["True", "False"] (C.Var "True")
     compile env (Var "x") `shouldBe` C.Int 1
@@ -379,7 +379,7 @@ taoTests = describe "--== Tao representation ==--" $ do
     eval env Err `shouldBe` Right (Err, Err)
     eval env TypT `shouldBe` Right (TypT, TypT)
     eval env IntT `shouldBe` Right (IntT, TypT)
-    eval env (Int 1) `shouldBe` Right (Int 1, IntT)
+    eval env (Int 42) `shouldBe` Right (Int 42, IntT)
     eval env (TupT []) `shouldBe` Right (TupT [], TypT)
     eval env (TupT [yT]) `shouldBe` Right (TupT [IntT], TypT)
     eval env (Tup []) `shouldBe` Right (Tup [], TupT [])
@@ -400,14 +400,13 @@ taoTests = describe "--== Tao representation ==--" $ do
     eval env (Set q []) `shouldBe` Right (q, RecT [("x", IntT), ("y", IntT)])
     eval env (Set q [("x", IntT)]) `shouldBe` Right (Set q [("x", IntT)], RecT [("x", TypT), ("y", IntT)])
     eval env (Set q [("z", IntT)]) `shouldBe` Right (Set q [("z", IntT)], RecT [("x", IntT), ("y", IntT), ("z", TypT)])
-    eval env neverT `shouldBe` Right (neverT, TypT)
-    eval env unitT `shouldBe` Right (unitT, TypT)
-    eval env monadT `shouldBe` Left (UndefinedVar "a")
+    eval env (Var "Never") `shouldBe` Right (neverT, TypT)
+    eval env (Var "Unit") `shouldBe` Right (unitT, TypT)
     eval env (Var "Monad") `shouldBe` Right (Lam "a" monadT, ForT "aT" (FunT (Var "aT") TypT))
-    eval env (App (Var "Monad") IntT) `shouldBe` Right (SumT "Monad" [("M", (["x"], FunT IntT (App (Var "Monad") IntT)))], TypT)
+    eval env (App (Var "Monad") IntT) `shouldBe` Right (SumT [("M", (["x"], FunT IntT (App (Var "Monad") IntT)))], TypT)
     eval env (Ctr "Unit" "A") `shouldBe` Right (Ctr "Unit" "A", unitT)
     eval env (Ctr "Bool" "True") `shouldBe` Right (Ctr "Bool" "True", boolT)
-    eval env (Ctr "Monad" "M") `shouldBe` Right (Ctr "Monad" "M", FunT a monadT)
+    eval env (Ctr "Monad" "M") `shouldBe` Right (Ctr "Monad" "M", ForT "a" (FunT a monadT))
     eval env (Var "x") `shouldBe` Right (Int 1, IntT)
     eval env (ForT "x" (TupT [x, yT])) `shouldBe` Right (ForT "x" (TupT [x, IntT]), TypT)
     eval env (FunT (TupT []) (TupT [])) `shouldBe` Right (FunT (TupT []) (TupT []), TypT)
@@ -436,3 +435,4 @@ taoTests = describe "--== Tao representation ==--" $ do
     eval env (sub x x) `shouldBe` Right (Int 0, IntT)
     eval env (mul x x) `shouldBe` Right (Int 1, IntT)
     eval env (eq x x) `shouldBe` Right (Ctr "Bool" "True", boolT)
+    eval env (Op $ Call "f" (TupT [])) `shouldBe` Right (Op $ Call "f" (TupT []), TupT [])


### PR DESCRIPTION
- Canonicalize every Tao expression except pattern matching
- Separate canonicalization into its own function (cleaner and simpler)
- More type inference fixes
- Add parser support for tuple types, record types, record getters, and record setters